### PR TITLE
add check expiration date for licensed file download

### DIFF
--- a/application/controllers/Access_licensed.php
+++ b/application/controllers/Access_licensed.php
@@ -314,8 +314,15 @@ class Access_licensed extends MY_Controller {
 		if ($download_times>=$download_limit)
 		{			
 			redirect('/access_licensed/expired/'.$request_id.'/'.$download_limit,"refresh");exit;
-		}				
-		
+		}
+
+		// Is the expiry date set by admin is passed ?
+		$expiry = $download_stats['expiry'];
+
+		if (time() > $expiry) {
+			redirect('/access_licensed/expired_date/'.$request_id.'/'.$expiry,"refresh");exit;
+		}
+
 		//increment the download tick
 		$this->Licensed_model->update_download_stats($file_id,$request_id,$user->email);
 		
@@ -475,9 +482,19 @@ class Access_licensed extends MY_Controller {
 		$this->template->write('content', $contents,true);
 		$this->template->render();
 	}
-	
-	
-	function additional_info($request_id=NULL)
+
+	function expired_date($requestid=NULL, $expiry=0)
+	{
+		$data['expiry'] = date($this->config->item('date_format'), $expiry);
+		$data['email']=$this->config->item("website_webmaster_email");
+		$contents=$this->load->view('access_licensed/date_limit_reached',$data,TRUE);
+
+		$this->template->set_template('default');
+		$this->template->write('content', $contents,true);
+		$this->template->render();
+	}
+
+    function additional_info($request_id=NULL)
 	{
 		if(!is_numeric($request_id))
 		{

--- a/application/language/base/licensed_request_lang.php
+++ b/application/language/base/licensed_request_lang.php
@@ -64,6 +64,7 @@ $lang['body']="Body";
 $lang['send']="Send";
 $lang['title_download_expired']="Download link has expired!";
 $lang['msg_download_limit_reached']="You have reached your download limit for this file. You are limited to %d downloads for this file. If you would like to have the number of downlaods allowed increased please write to %s to have this changed.";
+$lang['msg_date_limit_reached']="You have reached your download deadline for this file. The deadline was %s. If you would like to extend the deadline to access to the document, please write to %s to change the expiration date.";
 $lang['apply']="Apply";
 $lang['not_attached_any_licensed_files']="You have not attached any licensed files to the survey, visit the &quot;Licensed survey files&quot; page to setup files.";
 $lang['restrict_data_access_by_id']="Restrict data access by IP";

--- a/application/language/english/licensed_request_lang.php
+++ b/application/language/english/licensed_request_lang.php
@@ -64,6 +64,7 @@ $lang['body']="Body";
 $lang['send']="Send";
 $lang['title_download_expired']="Download link has expired!";
 $lang['msg_download_limit_reached']="You have reached your download limit for this file. You are limited to %d downloads for this file. If you would like to have the number of downlaods allowed increased please write to %s to have this changed.";
+$lang['msg_date_limit_reached']="You have reached your download deadline for this file. The deadline was %s. If you would like to extend the deadline to access to the document, please write to %s to change the expiration date.";
 $lang['apply']="Apply";
 $lang['not_attached_any_licensed_files']="You have not attached any licensed files to the survey, visit the &quot;Licensed survey files&quot; page to setup files.";
 $lang['restrict_data_access_by_id']="Restrict data access by IP";

--- a/application/views/access_licensed/date_limit_reached.php
+++ b/application/views/access_licensed/date_limit_reached.php
@@ -1,0 +1,4 @@
+<h1><?php echo t('title_download_expired');?></h1>
+<p>
+    <?php echo sprintf(t('msg_date_limit_reached'), $expiry, mailto($email));?>
+</p>


### PR DESCRIPTION
This fix provides the "expiry" date check set by admin for granted access files in "Edit licensed request" page when a user try to download a licensed data file.