### PR TITLE
add check permission on reports admin page

### DIFF
--- a/application/controllers/admin/Reports.php
+++ b/application/controllers/admin/Reports.php
@@ -15,9 +15,9 @@ class Reports extends MY_Controller {
  
 	function index()
 	{
-        $this->acl_manager->has_access_or_die('reports', 'view');
+		$this->acl_manager->has_access_or_die('reports', 'view');
 
-        $this->template->set_template('admin5');
+		$this->template->set_template('admin5');
 		//javascript/css needed for showing the date picker
 		$this->template->add_css('javascript/jquery/ui/themes/base/jquery-ui.css');
 		$this->template->add_js('javascript/jquery/ui/jquery.ui.js');	

--- a/application/controllers/admin/Reports.php
+++ b/application/controllers/admin/Reports.php
@@ -14,8 +14,10 @@ class Reports extends MY_Controller {
     }
  
 	function index()
-	{	
-		$this->template->set_template('admin5');		
+	{
+        $this->acl_manager->has_access_or_die('reports', 'view');
+
+        $this->template->set_template('admin5');
 		//javascript/css needed for showing the date picker
 		$this->template->add_css('javascript/jquery/ui/themes/base/jquery-ui.css');
 		$this->template->add_js('javascript/jquery/ui/jquery.ui.js');	


### PR DESCRIPTION
We noticed that the "Reports view" permission was not linked to the reports administration page and that anyone with access to the administration section could view the page.

There's a quick fix.