### PR TITLE
fix deleted user_roles when user edit own profile

### DIFF
--- a/application/models/Ion_auth_model.php
+++ b/application/models/Ion_auth_model.php
@@ -1010,14 +1010,14 @@ class Ion_auth_model extends CI_Model
 		
 		//user role membership
 
-		//remove any existing user roles
-		$this->db->query(sprintf('delete from %s where user_id=%d',
-							'user_roles', 
-							(int)$id ));
-
         //update user roles info
 		if (is_array($roles) && count($roles)>0)
 		{
+			//remove any existing user roles
+			$this->db->query(sprintf('delete from %s where user_id=%d',
+				'user_roles',
+				(int)$id ));
+
 			foreach($roles as $role_id)
 			{
 				$options=array(


### PR DESCRIPTION
There's a small bug when a user update his profile. All roles are deleted even if there's no role when submitting the profile form.