### PR TITLE
fix breadcrumb error in catalog edit page

### DIFF
--- a/application/libraries/Breadcrumb.php
+++ b/application/libraries/Breadcrumb.php
@@ -464,7 +464,7 @@ class Breadcrumb
 			switch ($segments[3])
 			{
 				case 'edit':
-					$breadcrumbs['admin/catalog/edit']=t('edit_study');
+					$breadcrumbs['admin/catalog/edit/'.$segments[4]]=t('edit_study');
 				break;
 				
 				case 'add_study':


### PR DESCRIPTION
There's a small bug in /admin/catalog/edit page with the "Edit study" link in breadcrumb. The Id is missing in url.
This patch adds the Id.