### PR TITLE
fix resources download link in resources tab in study edit page

### DIFF
--- a/application/views/catalog/study_resources.php
+++ b/application/views/catalog/study_resources.php
@@ -91,7 +91,7 @@
               <a href="<?php echo site_url();?>/admin/resources/edit/<?php echo $row->resource_id;?>/<?php echo $row->survey_id;?>"><?php echo t('edit'); ?></a> |
               <a href="<?php echo site_url();?>/admin/resources/delete/<?php echo $row->resource_id;?>/?destination=<?php echo $this->uri->uri_string();?>"><?php echo t('delete'); ?></a>
               <?php if($row->filename!=''):?>
-              | <a href="<?php echo site_url();?>/ddibrowser/<?php echo $survey_id; ?>/download/<?php echo $row->resource_id;?>"><?php echo t('download'); ?></a>
+              | <a href="<?php echo site_url();?>/catalog/<?php echo $survey_id; ?>/download/<?php echo $row->resource_id;?>"><?php echo t('download'); ?></a>
               <?php endif;?>
             </td>
         </tr>


### PR DESCRIPTION
Hi, 
In the resources tabs in study edit (/admin/catalog/edit/[study ID]/resources), the download link in currently "/ddibrowser/[study ID]/download/[Resource ID]" and it gives a 404 error each time.

This fix update the link with : /catalog/[study ID]/download/[Resource ID].
