### PR TITLE
fix access admin logs page

### DIFF
--- a/application/controllers/admin/Logs.php
+++ b/application/controllers/admin/Logs.php
@@ -22,7 +22,9 @@ class Logs extends MY_Controller {
 	}
 	
 	function index()
-	{			
+	{
+		$this->acl_manager->has_access_or_die('reports', 'view');
+
 		//get array of db rows		
 		$result['rows']=$this->_search();
 		


### PR DESCRIPTION
We noticed that the "Reports view" permission was not linked to the logs administration page and that anyone with access to the administration section could view the page.

There's a quick fix.