### PR TITLE
Fix broken links in Datadeposit section

### DIFF
--- a/application/libraries/Breadcrumb.php
+++ b/application/libraries/Breadcrumb.php
@@ -236,7 +236,7 @@ class Breadcrumb
 			break;
 
 			case 'datadeposit':
-					$breadcrumbs['data-deposit']=t('datadeposit');
+					$breadcrumbs['datadeposit']=t('datadeposit');
 					$breadcrumbs['datadeposit/projects']=t('my_projects');
 					$dd_array=array('summary', 'update', 'submit_review','study','datafiles','citations');
 					if(isset($segments[2]) && in_array($segments[2], $dd_array) && isset($segments[3]))

--- a/application/views/datadeposit/projects_by_user.php
+++ b/application/views/datadeposit/projects_by_user.php
@@ -83,7 +83,7 @@
                 <?php if ($project->status=='draft'):?>
                 <span>
                     <span class="glyphicon glyphicon-print" aria-hidden="true"></span>
-                    <a href="<?php echo site_url('datadeposit/summary'.$project->id);?>">Summary</a>
+                    <a href="<?php echo site_url('datadeposit/summary/'.$project->id);?>">Summary</a>
                 </span>
                 <?php endif;?>
 


### PR DESCRIPTION
There is a fix for two broken links in the datadeposit section.

The breadcrumb firsts link "data deposit" leads to (index.php)/data**-**deposit. The route doesn't exists.
The good link should be (index.php)/datadeposit without hyphen.

The second broken link is in the "My projects" page. The "Summary" link between "Edit" and "Delete" has a missing "/". 
It should be (index.php)/datadeposit/summary**/**X and not (index.php)/datadeposit/summaryX.