### PR TITLE
Fix datadeposit review send by email

### DIFF
--- a/application/controllers/Datadeposit.php
+++ b/application/controllers/Datadeposit.php
@@ -2004,7 +2004,7 @@ class Datadeposit extends MY_Controller {
 		$email = html_escape($this->input->post("email"));
 
 		if (! $this->DD_project_model->has_access($id, $this->session->userdata('email'))) {
-			echo json_encode(['error' => t("PERMISSIONS_DENIED")]);
+			echo json_encode(['error' => t("permissions_denied")]);
 			exit;
 		}
 
@@ -2012,7 +2012,7 @@ class Datadeposit extends MY_Controller {
 		$this->load->library('email');
 
 		if (! valid_email($email)) {
-			echo json_encode(['error' => t("INVALID_EMAIL_ADDRESS")]);
+			echo json_encode(['error' => t("invalid_email")]);
 			exit;
 		}
 
@@ -2043,10 +2043,10 @@ class Datadeposit extends MY_Controller {
 		$this->email->message($contents);
 
 		if (! @$this->email->send()) {
-			echo json_encode(['error' => t("EMAIL_FAILED")]);
+			echo json_encode(['error' => t("email_failed")]);
 			exit;
 		} else {
-			echo json_encode(['success' => t("EMAIL_SENT")]);
+			echo json_encode(['success' => t("email_sent_successful")]);
 			exit;
 		}
 	}

--- a/application/language/base/dd_projects_lang.php
+++ b/application/language/base/dd_projects_lang.php
@@ -193,5 +193,7 @@ $lang['msg_reopen_request'] = "<p>User <b>%s</b> has requested to reopen the pro
 <p>Reason for project reopen: <b>%s</b></p>
 ";
 
+$lang['permissions_denied'] = "Permissions denied!";
+
 /* End of file projects_lang.php */
 /* Location: ./system/language/english/projects_lang.php */

--- a/application/views/datadeposit/project_review_submit.php
+++ b/application/views/datadeposit/project_review_submit.php
@@ -55,19 +55,40 @@
 		
 		//send email
 		$('#send_email').click(function() {
-			$.post( "<?php echo site_url('datadeposit/email_summary/');?>", 
-				{ 
+
+			if (! $("#share_email").val()) {
+				alert('Email address is required');
+				return false;
+			}
+
+			$.ajax({
+				dataType: "json",
+				data:{
 					'<?php echo $this->security->get_csrf_token_name(); ?>': '<?php echo $this->security->get_csrf_hash(); ?>',
 					email: $("#share_email").val(),
 					pid: <?php echo $project[0]->id; ?>
-			} );
-			$("#email-project").hide();
+				},
+				type:'POST',
+				url: "<?php echo site_url('datadeposit/email_summary/');?>",
+				success: function(data) {
+					if (data.success){
+						$("#email-project").hide();
+						$("#share_email").val('');
+						alert(data.success);
+					} else {
+						alert(data.error);
+					}
+				},
+				error: function(XHR, textStatus, thrownError) {
+					alert(XHR.error);
+				}
+			});
 		});
-		
+
 		<?php if ($this->input->post("submit_project")):?>
 			//select submit tab
 			$('#tabs').tabs( "option", "active", 1 );
 		<?php endif;?>
-		
+
 	});
 </script>    


### PR DESCRIPTION
Hello,

A small improvement on the "Review and submit" page in the "Data deposit" section. Currently, when there is an error in the "share_email" field, the message displayed is not very clear. 
This fix allows you to have a detailed message with the correct translations.
I've also added a check on the field before the POST request to see whether it's empty or not.

Error message before
![2024-03-26 13_17_41-Data Deposit - Review and Submit](https://github.com/ihsn/nada/assets/1140186/785878cb-97dc-46ff-bb4d-327676a95569)
Error message after
![2024-03-26 13_26_23-Window](https://github.com/ihsn/nada/assets/1140186/a4098fa5-b726-43cc-a47a-295feb5a4b88)
