### PR TITLE
Fix csrf error in study notes

### DIFF
--- a/application/views/catalog/study_notes.php
+++ b/application/views/catalog/study_notes.php
@@ -59,25 +59,23 @@ $(function() {
 
 
 <div class="panel panel-default">
-  <div class="panel-body" style="background:#eee;">
+	<div class="panel-body" style="background:#eee;">
 		<?php echo form_open('admin/catalog_notes/add/'.$id, 'class="form-post-note" style="padding:10px;"'); ?>
 
-		<div class="form-group">
-		    <label class="inline"><?php echo t('select_note_type');?>
-		    <?php echo form_dropdown('type', array('admin'=>t('admin_note'),'reviewer'=>t('reviewer_note'),'public'=>t('public_note')),null,'class="edit_note_type"'); ?>
-		    </label>
-		</div>
+			<div class="form-group">
+		    	<label class="inline"><?php echo t('select_note_type');?>
+		    		<?php echo form_dropdown('type', array('admin'=>t('admin_note'),'reviewer'=>t('reviewer_note'),'public'=>t('public_note')),null,'class="edit_note_type"'); ?>
+		    	</label>
+			</div>
 
-		<div class="form-group">
-		    <textarea name="note" class="form-control note_body_text" rows="4" placeholder="<?php echo t('Type note...');?>" ></textarea>
-		</div>
-		<div class="form-group">
+			<div class="form-group">
+				<textarea name="note" class="form-control note_body_text" rows="4" placeholder="<?php echo t('Type note...');?>" ></textarea>
+			</div>
+			<div class="form-group">
 				<button id="submit-form" type="button" class="btn btn-default"><?php echo t('Submit');?></button>
-		</div>
+			</div>
 		<?php echo form_close(); ?>
-
-
-</div>
+	</div>
 </div>
 
 <div class="notes-container">

--- a/application/views/catalog/study_notes.php
+++ b/application/views/catalog/study_notes.php
@@ -62,8 +62,6 @@ $(function() {
   <div class="panel-body" style="background:#eee;">
 		<?php echo form_open('admin/catalog_notes/add/'.$id, 'class="form-post-note" style="padding:10px;"'); ?>
 
-		<input type="hidden" name="<?=$csrf['name'];?>" value="<?=$csrf['hash'];?>" />
-
 		<div class="form-group">
 		    <label class="inline"><?php echo t('select_note_type');?>
 		    <?php echo form_dropdown('type', array('admin'=>t('admin_note'),'reviewer'=>t('reviewer_note'),'public'=>t('public_note')),null,'class="edit_note_type"'); ?>


### PR DESCRIPTION
Hello,

The admin page "notes" in study edition show this PHP error in view template "catalog/study_notes.php":

> A PHP Error was encountered
> Severity: Warning
> Message: Undefined variable $csrf
> Filename: catalog/study_notes.php
> Line Number: 64

There's no need to have the input hidden with $csrf as the form_open() function takes care of this part.

There's a small fix with an updated indentation.